### PR TITLE
Fix/remove some npm modules

### DIFF
--- a/lib/map-values.ts
+++ b/lib/map-values.ts
@@ -1,0 +1,7 @@
+type ObjectIterator<TObject, TResult> = (value: TObject[keyof TObject], key: string) => TResult;
+
+export default function mapValues<T extends object, TResult>(obj: T, callback: ObjectIterator<T, TResult>): { [P in keyof T]: TResult } {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, callback(value, key)])
+  ) as any
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "design-tokens",
       "version": "0.1.0",
       "license": "UNLICENSED",
-      "dependencies": {
-        "polished": "^4.2.2"
-      },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.2",
         "@types/lodash.mapvalues": "^4.6.7",
@@ -19,6 +16,7 @@
         "@types/node": "^20.4.3",
         "lodash.set": "^4.3.2",
         "lodash.setwith": "^4.3.2",
+        "polished": "^4.2.2",
         "style-dictionary": "^3.7.2",
         "tailwindcss": "^3.2.7",
         "token-transformer": "0.0.30"
@@ -32,6 +30,7 @@
       "version": "7.22.11",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
       "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -949,6 +948,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz",
       "integrity": "sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8"
       },
@@ -1139,7 +1139,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "lodash.mapvalues": "^4.6.0",
         "polished": "^4.2.2"
       },
       "devDependencies": {
@@ -760,11 +759,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ=="
     },
     "node_modules/lodash.set": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,9 @@
     "@types/node": "^20.4.3",
     "lodash.set": "^4.3.2",
     "lodash.setwith": "^4.3.2",
+    "polished": "^4.2.2",
     "style-dictionary": "^3.7.2",
     "tailwindcss": "^3.2.7",
     "token-transformer": "0.0.30"
-  },
-  "dependencies": {
-    "polished": "^4.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "token-transformer": "0.0.30"
   },
   "dependencies": {
-    "lodash.mapvalues": "^4.6.0",
     "polished": "^4.2.2"
   }
 }

--- a/react-native/global/styles.ts
+++ b/react-native/global/styles.ts
@@ -1,4 +1,4 @@
-import mapValues from 'lodash.mapvalues';
+import mapValues from '../../lib/map-values'
 import colors from './colors';
 
 export const bg = mapValues(colors, value => ({backgroundColor: value}));


### PR DESCRIPTION
design-tokens 가 서브모듈의 서브모듈로 들어가기 때문에, careely-web에서 사용할 때

npm install (careelyr-web)
npm install (web-design-system)
npm install (design-tokens)

가 모두 실행되어야 하는데, 두번째까지는 submodules-install로 된다고 쳐도 한 번더 중첩된 submodule install을 하는 건 좀 빡세서 차라리 얼마 없는 라이브러리를 걷어내기로 하였습니다.