### PR TITLE
일반적인 색을 보더 색으로 사용 가능하게 수정

### DIFF
--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -1,10 +1,15 @@
 import mapValues from '../utils/map-values';
-import borderColors from './border-colors';
+import borderOnlyColors from './border-colors';
 import colors from './colors';
 
 export const colorValues = colors;
 
 export const bg = mapValues(colors, value => ({ backgroundColor: value }));
+
+const borderColors = {
+  ...colors,
+  ...borderOnlyColors,
+}
 
 export const border = {
   color: mapValues(borderColors, value => ({


### PR DESCRIPTION
컨테이너, 틴트 버튼의 경우 보더 색이 따로 정의되지 않더라도 배경색과 동일하게 사용하기 위해 사용 가능한 보더 색의 범위를 확장했습니다.