### PR TITLE
CFVM-153 아이콘 타입 대응 방식 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:mobile": "npm run transform:mobile && npm run style-dictionary:mobile",
     "build": "npm run build:pc && npm run build:mobile",
     "test": "tailwindcss -c example/tailwind.config.js -i example/input.css -o example/output.css",
-    "transform-icons:rn": "node dist/src/scripts/icon-to-rn && node dist/src/scripts/create-icon-index icons/rn",
+    "transform-icons:rn": "node dist/src/scripts/icon-to-rn && node dist/src/scripts/create-icon-index icons/rn && cp src/utils/DEPRECATED_Variables.ts icons/rn/DEPRECATED_Variables.ts",
     "transform-icons:web": "node dist/src/scripts/icon-to-web && node dist/src/scripts/create-icon-index icons/web",
     "transform-icons": "tsc && rm -rf icons && npm run transform-icons:rn && npm run transform-icons:web"
   },

--- a/src/scripts/icon-to-rn.ts
+++ b/src/scripts/icon-to-rn.ts
@@ -1,24 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-
-type IconType = {
-  [name: string]: {
-    svg: string;
-    name: string;
-    png: Record<string, string>;
-  };
-};
-
-function toPascalCase(str: string) {
-  return str
-    .replace(/([-_][a-z0-9])/g, group => group.toUpperCase().replace('-', '').replace('_', ''))
-    .replace(/^[a-z]/, firstLetter => firstLetter.toUpperCase());
-}
-
-function removeFillAttribute(svgString: string): string {
-  const fillRegex = /\sfill="[^"]*"/g;
-  return svgString.replace(fillRegex, '');
-}
+import { IconaDataType, TransformedIconsType, getSvgInnerHTML, removeFillAttribute, toPascalCase } from './utils';
 
 const iconsJsonPath = '.icona/icons.json';
 const outputDirectory = path.resolve('icons/rn');
@@ -28,43 +10,89 @@ if (!fs.existsSync(outputDirectory)) {
 }
 
 const iconsJsonContent = fs.readFileSync(iconsJsonPath, 'utf8');
-const iconsData: IconType = JSON.parse(iconsJsonContent);
+const iconsData: IconaDataType = JSON.parse(iconsJsonContent);
 
-const transformedIcons: {
-  [name: string]: {
-    solidPath: string;
-    outlinePath: string;
-  };
-} = {};
+const transformedIcons: TransformedIconsType = {};
 
 Object.values(iconsData).forEach(icon => {
   const iconNames = icon.name.split('_');
-  const iconType = iconNames.pop();
+  const iconType = iconNames.pop() ?? "default";
   const iconName = iconNames.join('-');
-  const pathType = iconType === 'yes' ? 'solidPath' : 'outlinePath';
   const filename = path.basename(toPascalCase(iconName.split('/')[1]), '.tsx');
-  const svgContent = icon.svg;
-  const svgRegex = /<svg[^>]*>([\s\S]*?)<\/svg>/;
-  const svgMatch = svgContent.match(svgRegex);
+  const svgMatch = getSvgInnerHTML(icon.svg);
   if (svgMatch) {
-    const svgPath = removeFillAttribute(svgMatch[1]);
-    transformedIcons[filename] = { ...transformedIcons[filename], [pathType]: svgPath };
+    const svgPath = removeFillAttribute(svgMatch);
+    transformedIcons[filename] = { ...transformedIcons[filename], [iconType]: svgPath };
   }
 });
 
 Object.entries(transformedIcons).forEach(([name, paths]) => {
   const outputFilePath = path.join(outputDirectory, `${name}Icon.tsx`);
-  try {
-    const outputFileContent = `import { iconGenerator } from '../utils/icon-utils';
+  const header = `/**\n * ${new Date()}에 자동 생성됨\n */`;
+  const stringifiedPaths = Object.entries(paths).map(([type, path]) => {
+    return `\n\t"${type}": '${path.replace(/\n/g, '')}'`;
+  })
 
-const ${name}Icon = iconGenerator({
-  solidPath: \`
-    ${paths.solidPath.trim()}
-  \`,
-  outlinePath: \`
-    ${paths.outlinePath.trim()}
-  \`
-});
+  try {
+    const outputFileContent = `${header}
+import Variables from './DEPRECATED_Variables';
+import { colorValues } from '../design-tokens/main/react-native';
+
+type TokenColorsType = keyof typeof colorValues;
+type VariablesColorsType = keyof typeof Variables.themeColors;
+type IconColorType = VariablesColorsType | TokenColorsType;
+
+const paths = {${stringifiedPaths.join(',')}
+};
+
+const isTokenColorType = (color: any): color is TokenColorsType => {
+  return color in colorValues;
+}
+
+const getIconColors = (fill?: IconColorType, stroke?: IconColorType) => {
+  const fillValue = isTokenColorType(fill)
+    ? colorValues[fill]
+    : Variables.themeColors[fill ?? 'black'];
+  const strokeValue = stroke
+    ? isTokenColorType(stroke)
+      ? colorValues[stroke]
+      : Variables.themeColors[stroke]
+    : fillValue;
+  return { fillValue, strokeValue };
+};
+
+const ${name}Icon = (
+  params: {
+    type?: keyof typeof paths;
+    width?: number;
+    height?: number;
+    fill?: IconColorType;
+    stroke?: IconColorType;
+    strokeWidth?: number;
+  } = {},
+) => {
+  const {
+    type = Object.keys(paths)[0] as keyof typeof paths,
+    width = 24,
+    height = 24,
+    fill = 'colorBlack',
+    stroke,
+    strokeWidth = 0,
+  } = params;
+  const { fillValue, strokeValue } = getIconColors(fill, stroke);
+  const path = paths[type];
+
+  return \`<svg 
+            width="\${width}" 
+            height="\${height}" 
+            fill="\${fillValue}"  
+            stroke="\${strokeValue}" 
+            strokeWidth="\${strokeWidth}"
+            viewBox="0 0 24 24" 
+          >
+            \${path}
+          </svg>\`;
+};
 
 export default ${name}Icon;
 `;

--- a/src/scripts/icon-to-rn.ts
+++ b/src/scripts/icon-to-rn.ts
@@ -28,14 +28,19 @@ Object.values(iconsData).forEach(icon => {
     const svgPath = removeFillAttribute(svgMatch);
     transformedIcons[filename] = {
       ...transformedIcons[filename],
-      [iconType ?? 'outline']: svgPath,
+      [iconType]: svgPath,
     };
   }
 });
 
 Object.entries(transformedIcons).forEach(([name, paths]) => {
+  if (!('outline' in paths)) {
+    throw new Error(`Icon ${name} does not have an outline type`);
+  }
+
   const outputFilePath = path.join(outputDirectory, `${name}Icon.tsx`);
   const header = `/**\n * 직접 수정 금지 - 스크립트로 자동 생성됨\n */`;
+
   const stringifiedPaths = Object.entries(paths).map(([type, path]) => {
     return `\n\t"${type}": '${path.replace(/\n/g, '')}'`;
   });

--- a/src/scripts/icon-to-web.ts
+++ b/src/scripts/icon-to-web.ts
@@ -1,24 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-
-type IconType = {
-  [name: string]: {
-    svg: string;
-    name: string;
-    png: Record<string, string>;
-  };
-};
-
-function toPascalCase(str: string) {
-  return str
-    .replace(/([-_][a-z0-9])/g, group => group.toUpperCase().replace('-', '').replace('_', ''))
-    .replace(/^[a-z]/, firstLetter => firstLetter.toUpperCase());
-}
-
-function removeFillAttribute(svgString: string): string {
-  const fillRegex = /\sfill="[^"]*"/g;
-  return svgString.replace(fillRegex, '');
-}
+import { IconaDataType, TransformedIconsType, getSvgInnerHTML, removeFillAttribute, toPascalCase } from './utils';
 
 const iconsJsonPath = '.icona/icons.json';
 const outputDirectory = path.resolve('icons/web');
@@ -28,53 +10,42 @@ if (!fs.existsSync(outputDirectory)) {
 }
 
 const iconsJsonContent = fs.readFileSync(iconsJsonPath, 'utf8');
-const iconsData: IconType = JSON.parse(iconsJsonContent);
+const iconsData: IconaDataType = JSON.parse(iconsJsonContent);
 
-const transformedIcons: {
-  [name: string]: {
-    solidPath: string;
-    outlinePath: string;
-  };
-} = {};
+const transformedIcons: TransformedIconsType = {};
 
 Object.values(iconsData).forEach(icon => {
   const iconNames = icon.name.split('_');
-  const iconType = iconNames.pop();
+  const iconType = iconNames.pop() ?? "default";
   const iconName = iconNames.join('-');
-  const pathType = iconType === 'yes' ? 'solidPath' : 'outlinePath';
   const filename = path.basename(toPascalCase(iconName.split('/')[1]), '.tsx');
-  const svgContent = icon.svg;
-  const svgRegex = /<svg[^>]*>([\s\S]*?)<\/svg>/;
-  const svgMatch = svgContent.match(svgRegex);
+  const svgMatch = getSvgInnerHTML(icon.svg);
   if (svgMatch) {
-    const svgPath = removeFillAttribute(svgMatch[1]);
-    transformedIcons[filename] = { ...transformedIcons[filename], [pathType]: svgPath };
+    const svgPath = removeFillAttribute(svgMatch);
+    if (!transformedIcons[filename]) {
+      transformedIcons[filename] = {};
+    }
+    transformedIcons[filename][iconType] = svgPath;
   }
 });
 
 Object.entries(transformedIcons).forEach(([name, paths]) => {
   const outputFilePath = path.join(outputDirectory, `${name}Icon.tsx`);
+  const header = `/**\n * ${new Date()}에 자동 생성됨\n */`;
+  const stringifiedPaths = Object.entries(paths).map(([type, path]) => {
+    return `\n\t"${type}": ${path.replace(/\n/g, '')}`;
+  })
 
-  const outputFileContent = `import * as React from 'react';
+  const outputFileContent = `${header}
+import * as React from 'react';
 
-type Props = React.SVGProps<SVGSVGElement> & { type?: 'solid' | 'outline' };
+const paths = {${stringifiedPaths.join(',')}
+};
 
-function ${name}Icon(props: Props) {
-  if (props.type === 'solid') {
-    return (
-      <svg
-        width="24"
-        height="24"
-        strokeWidth="0"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-        {...props}
-      >
-        ${paths.solidPath.trim()}
-      </svg>
-    );
-  }
+type Props = React.SVGProps<SVGSVGElement> & { type?: keyof typeof paths };
 
+function ${name}Icon({ type = Object.keys(paths)[0] as keyof typeof paths, ...props }: Props) {
+  const path = paths[type];
   return (
     <svg
       width="24"
@@ -84,7 +55,7 @@ function ${name}Icon(props: Props) {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      ${paths.outlinePath.trim()}
+      {path}
     </svg>
   );
 }

--- a/src/scripts/icon-to-web.ts
+++ b/src/scripts/icon-to-web.ts
@@ -1,6 +1,12 @@
 import fs from 'fs';
 import path from 'path';
-import { IconaDataType, TransformedIconsType, getSvgInnerHTML, removeFillAttribute, toPascalCase } from './utils';
+import {
+  IconaDataType,
+  TransformedIconsType,
+  getSvgInnerHTML,
+  removeFillAttribute,
+  toPascalCase,
+} from './utils';
 
 const iconsJsonPath = '.icona/icons.json';
 const outputDirectory = path.resolve('icons/web');
@@ -15,9 +21,7 @@ const iconsData: IconaDataType = JSON.parse(iconsJsonContent);
 const transformedIcons: TransformedIconsType = {};
 
 Object.values(iconsData).forEach(icon => {
-  const iconNames = icon.name.split('_');
-  const iconType = iconNames.pop() ?? "default";
-  const iconName = iconNames.join('-');
+  const [iconName, iconType] = icon.name.split('_');
   const filename = path.basename(toPascalCase(iconName.split('/')[1]), '.tsx');
   const svgMatch = getSvgInnerHTML(icon.svg);
   if (svgMatch) {
@@ -25,16 +29,16 @@ Object.values(iconsData).forEach(icon => {
     if (!transformedIcons[filename]) {
       transformedIcons[filename] = {};
     }
-    transformedIcons[filename][iconType] = svgPath;
+    transformedIcons[filename][iconType ?? 'outline'] = svgPath;
   }
 });
 
 Object.entries(transformedIcons).forEach(([name, paths]) => {
   const outputFilePath = path.join(outputDirectory, `${name}Icon.tsx`);
-  const header = `/**\n * ${new Date()}에 자동 생성됨\n */`;
+  const header = `/**\n * 직접 수정 금지 - 스크립트로 자동 생성됨\n */`;
   const stringifiedPaths = Object.entries(paths).map(([type, path]) => {
     return `\n\t"${type}": ${path.replace(/\n/g, '')}`;
-  })
+  });
 
   const outputFileContent = `${header}
 import * as React from 'react';

--- a/src/scripts/icon-to-web.ts
+++ b/src/scripts/icon-to-web.ts
@@ -29,11 +29,15 @@ Object.values(iconsData).forEach(icon => {
     if (!transformedIcons[filename]) {
       transformedIcons[filename] = {};
     }
-    transformedIcons[filename][iconType ?? 'outline'] = svgPath;
+    transformedIcons[filename][iconType] = svgPath;
   }
 });
 
 Object.entries(transformedIcons).forEach(([name, paths]) => {
+  if (!('outline' in paths)) {
+    throw new Error(`Icon ${name} does not have an outline type`);
+  }
+
   const outputFilePath = path.join(outputDirectory, `${name}Icon.tsx`);
   const header = `/**\n * 직접 수정 금지 - 스크립트로 자동 생성됨\n */`;
   const stringifiedPaths = Object.entries(paths).map(([type, path]) => {

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -1,0 +1,40 @@
+
+export type IconaDataType = {
+  [name: string]: {
+    svg: string;
+    name: string;
+    png: Record<string, string>;
+  };
+};
+
+export type TransformedIconsType = {
+  [name: string]: {
+    [type: string]: string;
+  };
+}
+
+export function toPascalCase(str: string) {
+  return str
+    .replace(/([-_][a-z0-9])/g, group => group.replace('-', '').replace('_', '').toUpperCase())
+    .replace(/^[a-z]/, firstLetter => firstLetter.toUpperCase());
+}
+
+/**
+ * Remove fill attribute from svg tag string
+ */
+export function removeFillAttribute(svgString: string): string {
+  const fillRegex = /\sfill="[^"]*"/g;
+  return svgString.replace(fillRegex, '');
+}
+
+/**
+ * Get inner html (<g/>, <path/>, ...) of svg tag string
+ */
+export const getSvgInnerHTML = (svgString: string): string | undefined => {
+  const svgRegex = /<svg[^>]*>([\s\S]*?)<\/svg>/;
+  const svgMatch = svgString.match(svgRegex);
+  if (svgMatch) {
+    return svgMatch[1];
+  }
+  return undefined;
+}

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -1,4 +1,3 @@
-
 export type IconaDataType = {
   [name: string]: {
     svg: string;
@@ -11,7 +10,7 @@ export type TransformedIconsType = {
   [name: string]: {
     [type: string]: string;
   };
-}
+};
 
 export function toPascalCase(str: string) {
   return str
@@ -37,4 +36,4 @@ export const getSvgInnerHTML = (svgString: string): string | undefined => {
     return svgMatch[1];
   }
   return undefined;
-}
+};

--- a/src/utils/DEPRECATED_Variables.ts
+++ b/src/utils/DEPRECATED_Variables.ts
@@ -1,0 +1,325 @@
+/**
+ * @deprecated
+ **/
+export default class DEPRECATED_Variables {
+  // Color system
+  static black = '#000000';
+  static white = '#ffffff';
+
+  static slate50 = '#F8FAFC';
+  static slate100 = '#F1F5F9';
+  static slate200 = '#E2E8F0';
+  static slate300 = '#CBD5E1';
+  static slate400 = '#94A3B8';
+  static slate500 = '#64748B';
+  static slate600 = '#475569';
+  static slate700 = '#334155';
+  static slate800 = '#1E293B';
+  static slate900 = '#0F172A';
+
+  static gray100 = '#F8FAFC';
+  // 현재 gray100에 slate50값 적용되어있음
+  static gray200 = '#E2E8F0';
+  static gray300 = '#CBD5E1';
+  static gray400 = '#CBD5E1';
+  // 현재 gray400에 slate300값 적용되어있음
+  static gray500 = '#94A3B8';
+  // 현재 gray500에 slate400값 적용되어있음
+  static gray600 = '#94A3B8';
+  // 현재 gray600에 slate400값 적용되어있음
+  static gray700 = '#64748B';
+  // 현재 gray700에 slate500값 적용되어있음
+  static gray800 = '#475569';
+  // 현재 gray800에 slate600값 적용되어있음
+  static gray900 = '#0F172A';
+
+  static coral50 = '#FDF4F3';
+  static coral100 = '#ffedee';
+  static coral200 = '#FDD1CB';
+  static coral300 = '#F7B4AA';
+  static coral400 = '#f39b8e';
+  static coral500 = '#ef7b6a';
+  static coral600 = '#ed6653';
+  static coral700 = '#e1432e';
+  static coral800 = '#be1e08';
+  static coral900 = '#7A2D22';
+
+  static teal50 = '#F0FDFA';
+  static teal100 = '#CCFBF1';
+  static teal200 = '#99F6E4';
+  static teal300 = '#5EEAD4';
+  static teal400 = '#2DD4Bf';
+  static teal500 = '#14B8A6';
+  static teal600 = '#0D9488';
+  static teal700 = '#0F766E';
+  static teal800 = '#115E59';
+  static teal900 = '#134E4A';
+
+  static red50 = '#FEF2F2';
+  static red100 = '#FEE2E2';
+  static red200 = '#FECACA';
+  static red300 = '#FCA5A5';
+  static red400 = '#F87171';
+  static red500 = '#EF4444';
+  static red600 = '#DC2626';
+  static red700 = '#B91C1C';
+  static red800 = '#991B1B';
+  static red900 = '#7F1D1D';
+
+  static green50 = '#F0FDF4';
+  static green100 = '#DCFCE7';
+  static green200 = '#BBF7D0';
+  static green300 = '#86EFAC';
+  static green400 = '#4ADE80';
+  static green500 = '#22C55E';
+  static green600 = '#16A34A';
+  static green700 = '#15803D';
+  static green800 = '#166534';
+  static green900 = '#14532D';
+
+  static yellow50 = '#FEFCE8';
+  static yellow100 = '#FEF9C3';
+  static yellow200 = '#FEF08A';
+  static yellow300 = '#FDE047';
+  static yellow400 = '#FACC15';
+  static yellow500 = '#EAB308';
+  static yellow600 = '#CA8A04';
+  static yellow700 = '#A16207';
+  static yellow800 = '#854D0E';
+  static yellow900 = '#713F12';
+
+  static blue50 = '#EFF6FF';
+  static blue100 = '#DBEAFE';
+  static blue200 = '#BFDBFE';
+  static blue300 = '#93C5FD';
+  static blue400 = '#60A5FA';
+  static blue500 = '#3B82F6';
+  static blue600 = '#2563EB';
+  static blue700 = '#1D4ED8';
+  static blue800 = '#1E40AF';
+  static blue900 = '#1E3A8A';
+
+  static indigo50 = '#EEF2FF';
+  static indigo100 = '#E0E7FF';
+  static indigo200 = '#C7D2FE';
+  static indigo300 = '#A5B4FC';
+  static indigo400 = '#818CF8';
+  static indigo500 = '#6366F1';
+  static indigo600 = '#4F46E5';
+  static indigo700 = '#4338CA';
+  static indigo800 = '#3730A3';
+  static indigo900 = '#312E81';
+
+  static purple50 = '#FAF5FF';
+  static purple100 = '#F3E8FF';
+  static purple200 = '#E9D5FF';
+  static purple300 = '#D8B4FE';
+  static purple400 = '#C084FC';
+  static purple500 = '#A855F7';
+  static purple600 = '#9333EA';
+  static purple700 = '#7E22CE';
+  static purple800 = '#6B21A8';
+  static purple900 = '#581C87';
+
+  static magenta50 = '#FDF4FF';
+  static magenta100 = '#FAE8FF';
+  static magenta200 = '#F5D0FE';
+  static magenta300 = '#F0ABFC';
+  static magenta400 = '#E879F9';
+  static magenta500 = '#D946EF';
+  static magenta600 = '#C026D3';
+  static magenta700 = '#A21CAF';
+  static magenta800 = '#86198F';
+  static magenta900 = '#701A75';
+
+  static themeColors = {
+    black: DEPRECATED_Variables.black,
+    white: DEPRECATED_Variables.white,
+    slate50: DEPRECATED_Variables.slate50,
+    slate100: DEPRECATED_Variables.slate100,
+    slate200: DEPRECATED_Variables.slate200,
+    slate300: DEPRECATED_Variables.slate300,
+    slate400: DEPRECATED_Variables.slate400,
+    slate500: DEPRECATED_Variables.slate500,
+    slate600: DEPRECATED_Variables.slate600,
+    slate700: DEPRECATED_Variables.slate700,
+    slate800: DEPRECATED_Variables.slate800,
+    slate900: DEPRECATED_Variables.slate900,
+    gray100: DEPRECATED_Variables.gray100,
+    gray200: DEPRECATED_Variables.gray200,
+    gray300: DEPRECATED_Variables.gray300,
+    gray400: DEPRECATED_Variables.gray400,
+    gray500: DEPRECATED_Variables.gray500,
+    gray600: DEPRECATED_Variables.gray600,
+    gray700: DEPRECATED_Variables.gray700,
+    gray800: DEPRECATED_Variables.gray800,
+    gray900: DEPRECATED_Variables.gray900,
+    coral50: DEPRECATED_Variables.coral50,
+    coral100: DEPRECATED_Variables.coral100,
+    coral200: DEPRECATED_Variables.coral200,
+    coral300: DEPRECATED_Variables.coral300,
+    coral400: DEPRECATED_Variables.coral400,
+    coral500: DEPRECATED_Variables.coral500,
+    coral600: DEPRECATED_Variables.coral600,
+    coral700: DEPRECATED_Variables.coral700,
+    coral800: DEPRECATED_Variables.coral800,
+    coral900: DEPRECATED_Variables.coral900,
+    teal50: DEPRECATED_Variables.teal50,
+    teal100: DEPRECATED_Variables.teal100,
+    teal200: DEPRECATED_Variables.teal200,
+    teal300: DEPRECATED_Variables.teal300,
+    teal400: DEPRECATED_Variables.teal400,
+    teal500: DEPRECATED_Variables.teal500,
+    teal600: DEPRECATED_Variables.teal600,
+    teal700: DEPRECATED_Variables.teal700,
+    teal800: DEPRECATED_Variables.teal800,
+    teal900: DEPRECATED_Variables.teal900,
+    red50: DEPRECATED_Variables.red50,
+    red100: DEPRECATED_Variables.red100,
+    red200: DEPRECATED_Variables.red200,
+    red300: DEPRECATED_Variables.red300,
+    red400: DEPRECATED_Variables.red400,
+    red500: DEPRECATED_Variables.red500,
+    red600: DEPRECATED_Variables.red600,
+    red700: DEPRECATED_Variables.red700,
+    red800: DEPRECATED_Variables.red800,
+    red900: DEPRECATED_Variables.red900,
+    green50: DEPRECATED_Variables.green50,
+    green100: DEPRECATED_Variables.green100,
+    green200: DEPRECATED_Variables.green200,
+    green300: DEPRECATED_Variables.green300,
+    green400: DEPRECATED_Variables.green400,
+    green500: DEPRECATED_Variables.green500,
+    green600: DEPRECATED_Variables.green600,
+    green700: DEPRECATED_Variables.green700,
+    green800: DEPRECATED_Variables.green800,
+    green900: DEPRECATED_Variables.green900,
+    yellow50: DEPRECATED_Variables.yellow50,
+    yellow100: DEPRECATED_Variables.yellow100,
+    yellow200: DEPRECATED_Variables.yellow200,
+    yellow300: DEPRECATED_Variables.yellow300,
+    yellow400: DEPRECATED_Variables.yellow400,
+    yellow500: DEPRECATED_Variables.yellow500,
+    yellow600: DEPRECATED_Variables.yellow600,
+    yellow700: DEPRECATED_Variables.yellow700,
+    yellow800: DEPRECATED_Variables.yellow800,
+    yellow900: DEPRECATED_Variables.yellow900,
+    blue50: DEPRECATED_Variables.blue50,
+    blue100: DEPRECATED_Variables.blue100,
+    blue200: DEPRECATED_Variables.blue200,
+    blue300: DEPRECATED_Variables.blue300,
+    blue400: DEPRECATED_Variables.blue400,
+    blue500: DEPRECATED_Variables.blue500,
+    blue600: DEPRECATED_Variables.blue600,
+    blue700: DEPRECATED_Variables.blue700,
+    blue800: DEPRECATED_Variables.blue800,
+    blue900: DEPRECATED_Variables.blue900,
+    indigo50: DEPRECATED_Variables.indigo50,
+    indigo100: DEPRECATED_Variables.indigo100,
+    indigo200: DEPRECATED_Variables.indigo200,
+    indigo300: DEPRECATED_Variables.indigo300,
+    indigo400: DEPRECATED_Variables.indigo400,
+    indigo500: DEPRECATED_Variables.indigo500,
+    indigo600: DEPRECATED_Variables.indigo600,
+    indigo700: DEPRECATED_Variables.indigo700,
+    indigo800: DEPRECATED_Variables.indigo800,
+    indigo900: DEPRECATED_Variables.indigo900,
+    purple50: DEPRECATED_Variables.purple50,
+    purple100: DEPRECATED_Variables.purple100,
+    purple200: DEPRECATED_Variables.purple200,
+    purple300: DEPRECATED_Variables.purple300,
+    purple400: DEPRECATED_Variables.purple400,
+    purple500: DEPRECATED_Variables.purple500,
+    purple600: DEPRECATED_Variables.purple600,
+    purple700: DEPRECATED_Variables.purple700,
+    purple800: DEPRECATED_Variables.purple800,
+    purple900: DEPRECATED_Variables.purple900,
+    magenta50: DEPRECATED_Variables.magenta50,
+    magenta100: DEPRECATED_Variables.magenta100,
+    magenta200: DEPRECATED_Variables.magenta200,
+    magenta300: DEPRECATED_Variables.magenta300,
+    magenta400: DEPRECATED_Variables.magenta400,
+    magenta500: DEPRECATED_Variables.magenta500,
+    magenta600: DEPRECATED_Variables.magenta600,
+    magenta700: DEPRECATED_Variables.magenta700,
+    magenta800: DEPRECATED_Variables.magenta800,
+    magenta900: DEPRECATED_Variables.magenta900,
+  };
+
+  // Spacing
+  static spacer = 16;
+  static spacers = {
+    '0': 0,
+    '1': DEPRECATED_Variables.spacer * 0.25,
+    '2': DEPRECATED_Variables.spacer * 0.5,
+    '3': DEPRECATED_Variables.spacer * 0.75,
+    '4': DEPRECATED_Variables.spacer,
+    '5': DEPRECATED_Variables.spacer * 1.25,
+    '6': DEPRECATED_Variables.spacer * 1.5,
+    '7': DEPRECATED_Variables.spacer * 1.75,
+    '8': DEPRECATED_Variables.spacer * 2,
+    '9': DEPRECATED_Variables.spacer * 2.25,
+  };
+
+  // Sizing
+  static sizes = {
+    '10': '10%',
+    '15': '15%',
+    '25': '25%',
+    '31': '31.6%',
+    '33': '33.3%',
+    '35': '35%',
+    '50': '50%',
+    '66': '66.7%',
+    '75': '75%',
+    '100': '100%',
+    auto: 'auto',
+  };
+
+  static fontSizes = {
+    fontSize5XLarge: 3,
+    fontSize4XLarge: 2.25,
+    fontSize3XLarge: 1.875,
+    fontSize2XLarge: 1.5,
+    fontSizeXLarge: 1.25,
+    fontSizeLarge: 1.125,
+    fontSizeMedium: 1,
+    fontSizeSmall: 0.875,
+    fontSizeXSmall: 0.75,
+  };
+
+  static fontLeading = {
+    none: 1,
+    tight: 1.3,
+    normal: 1.5,
+    loose: 1.8,
+  };
+
+  static fontTracking = {
+    tight: -0.05,
+    normal: 0,
+    wide: 0.05,
+  };
+
+  // font
+  static baseFontSize = 16;
+
+  static baseLineHeight = 1.5;
+
+  // border
+
+  static borderWidth = 1;
+  static borderColor = DEPRECATED_Variables.gray300;
+
+  static borderRadiusSmall = DEPRECATED_Variables.baseFontSize * 0.125;
+  static borderRadius = DEPRECATED_Variables.baseFontSize * 0.25;
+  static borderRadiusMedium = DEPRECATED_Variables.baseFontSize * 0.375;
+  static borderRadiusLarge = DEPRECATED_Variables.baseFontSize * 0.5;
+  static borderRadiusXLarge = DEPRECATED_Variables.baseFontSize * 0.75;
+  static borderRadius2Xlarge = DEPRECATED_Variables.baseFontSize * 1;
+  static borderRadius3Xlarge = DEPRECATED_Variables.baseFontSize * 1.5;
+  static borderRadiusFull = DEPRECATED_Variables.baseFontSize * 1000;
+
+  static roundedCircle = DEPRECATED_Variables.baseFontSize * 1000;
+  static roundedPill = DEPRECATED_Variables.baseFontSize * 1000;
+}


### PR DESCRIPTION
# 변경사항

- `IconaDataType`, `TransformedIconsType`, `getSvgInnerHTML`, `removeFillAttribute`, `toPascalCase` 등의 함수를 src/scripts/utils.ts로 뺐습니다.
- 아이콘 변환 스크립트가 수정되었습니다.
  - RN: `iconGenerator`의 코드를 각 아이콘 코드 내부로 넣음 -> 디펜던시를 하나 제거
  - 공통: solid/outline 타입을 명시하지 않고 데이터에서 동적으로 타입 생성 가능하도록 변경했습니다
- `package.json`의 RN아이콘 생성 스크립트 수정
  - `DEPRECATED_Variables.ts`를 추출된 아이콘 폴더에 같이 넣어줌